### PR TITLE
feat: Register ping command and add registration tests

### DIFF
--- a/tests/commands/test_main.py
+++ b/tests/commands/test_main.py
@@ -1,0 +1,43 @@
+# tests/commands/test_main.py
+"""Tests for the main Typer app in src/mcp_cli/main.py."""
+
+from typer.testing import CliRunner
+
+from mcp_cli.main import app
+
+runner = CliRunner()
+
+
+def test_ping_command_exists():
+    """Test that 'mcp-cli ping' command is registered."""
+    result = runner.invoke(app, ["ping", "--help"])
+    assert result.exit_code == 0
+    assert "Test connectivity to MCP servers" in result.stdout
+
+def test_all_direct_commands_are_registered():
+    """
+    Test that all commands intended for direct registration are present.
+    This prevents commands from being accidentally removed.
+    """
+    # This list should be kept in sync with the commands registered in main.py
+    expected_commands = [
+        "chat",
+        "interactive",
+        "provider",
+        "providers",
+        "tools",
+        "servers",
+        "resources",
+        "prompts",
+        "models",
+        "theme",
+        "token",
+        "tokens",
+        "cmd",
+        "ping",
+    ]
+
+    registered_commands = [cmd.name for cmd in app.registered_commands if cmd.name]
+
+    for cmd_name in expected_commands:
+        assert cmd_name in registered_commands, f"Command '{cmd_name}' is not registered in main.py"


### PR DESCRIPTION
## Why

This commit addresses an issue where the `mcp-cli ping` command was not registered, causing a "No such command 'ping'" error:

```bash

> mcp-cli ping
✓ MCP CLI ready
ℹ   Available commands: chat, cmd, models, ping, prompts, provider, providers, resources, servers, theme, token, tokens, tools
  Use --help to see all options
Usage: mcp-cli [OPTIONS] COMMAND [ARGS]...
Try 'mcp-cli --help' for help.
╭─ Error ─────────────────────────────────────────────────────────────────────────────────────────────────╮
│ No such command 'ping'.                                                                                 │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

## Changes

- Registered the `ping` command in `src/mcp_cli/main.py`, making it accessible through the CLI.
- The `ping` command's implementation was updated to retrieve the `ToolManager` from the global context, resolving a `KeyError`.

## Tests

- Added a new test file, `tests/commands/test_main.py`, to ensure that the `ping` command and other core commands are properly registered, preventing future regressions.

## Notes

ping does not work with SSE servers. This is a bug as far as I can tell.