### PR TITLE
dependabot: Add cooldown and remove prefix-scope

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,8 @@ updates:
       day: "monday"
       time: "03:00"
     commit-message:
-      prefix: "chore"
-      prefix-scope: "deps"
+      prefix: "chore(deps)"
+    cooldown:
+      semver-patch-days: 3
+      semver-minor-days: 7
+      semver-major-days: 14


### PR DESCRIPTION
## Summary

Fixes invalid Dependabot configuration and adds cooldown periods for version updates.

## Changes

- **fix**: Remove invalid `prefix-scope` property from commit-message configuration
  - Consolidated scope into `prefix` as `chore(deps)` to comply with Dependabot schema
- **feat**: Add cooldown periods for GitHub Actions updates
  - Patch updates: 3-day delay
  - Minor updates: 7-day delay
  - Major updates: 14-day delay

## Motivation

The existing configuration contained an invalid `prefix-scope` property that violated the Dependabot
v2 schema. The cooldown feature allows new action releases to stabilize before creating update PRs,
reducing churn from rapidly-patched releases while maintaining security (security updates bypass
cooldown).