### PR TITLE
fix(dependabot): Update cooldown settings to use default-days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,4 @@ updates:
     commit-message:
       prefix: "chore(deps)"
     cooldown:
-      semver-patch-days: 3
-      semver-minor-days: 7
-      semver-major-days: 14
+      default-days: 14


### PR DESCRIPTION
Apparently semver is not supported for GHA.

* Replace `semver-patch-days`, `semver-minor-days`, and `semver-major-days` with the `default-days` setting in `.github/dependabot.yml`.
* Set the default dependency review cooldown to 14 days.