### PR TITLE
feat: unify version management with --version/-V flag

### DIFF
--- a/src/mcp_cli/__init__.py
+++ b/src/mcp_cli/__init__.py
@@ -38,5 +38,9 @@ os.environ.setdefault("CHUK_LLM_AUTO_DISCOVER", "true")
 os.environ.setdefault("CHUK_LLM_OPENAI_TOOL_COMPATIBILITY", "true")
 os.environ.setdefault("CHUK_LLM_UNIVERSAL_TOOLS", "true")
 
-__version__ = "1.0.0"
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
+try:
+    __version__ = _pkg_version("mcp-cli")
+except PackageNotFoundError:
+    __version__ = "0.0.0-dev"
 __all__ = ["__version__"]

--- a/src/mcp_cli/apps/host.py
+++ b/src/mcp_cli/apps/host.py
@@ -39,13 +39,12 @@ from mcp_cli.config.defaults import (
     DEFAULT_HTTP_REQUEST_TIMEOUT,
 )
 
+from mcp_cli.config import APP_VERSION
+
 if TYPE_CHECKING:
     from mcp_cli.tools.manager import ToolManager
 
 logger = logging.getLogger(__name__)
-
-# Version injected into the host page
-_MCP_CLI_VERSION = "0.13"
 
 # Strict regex for CSP source values — reject anything that could break out
 # of an HTML attribute or inject additional directives.
@@ -288,7 +287,7 @@ class AppHostServer:
             tool_name=safe_tool_name,
             port=app_info.port,
             csp_attr=csp_attr,
-            mcp_cli_version=_MCP_CLI_VERSION,
+            mcp_cli_version=APP_VERSION,
             init_timeout=DEFAULT_APP_INIT_TIMEOUT,
         )
         host_page_bytes = host_page.encode("utf-8")

--- a/src/mcp_cli/main.py
+++ b/src/mcp_cli/main.py
@@ -30,7 +30,7 @@ from chuk_term.ui import (
     restore_terminal,
 )
 from chuk_term.ui.theme import set_theme
-from mcp_cli.config import process_options
+from mcp_cli.config import process_options, APP_VERSION
 from mcp_cli.context import initialize_context
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -56,11 +56,26 @@ app = typer.Typer(add_completion=False)
 
 
 # ──────────────────────────────────────────────────────────────────────────────
+# Version callback
+# ──────────────────────────────────────────────────────────────────────────────
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"mcp-cli {APP_VERSION}")
+        raise typer.Exit()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
 # Default callback that handles no-subcommand case
 # ──────────────────────────────────────────────────────────────────────────────
 @app.callback(invoke_without_command=True)
 def main_callback(
     ctx: typer.Context,
+    version: bool = typer.Option(
+        None, "--version", "-V",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show version and exit.",
+    ),
     config_file: str = typer.Option(
         "server_config.json", help="Configuration file path"
     ),


### PR DESCRIPTION
## Summary
- Replace hardcoded version strings with dynamic version from `importlib.metadata`
- `__init__.py`: read `__version__` from installed package metadata instead of `"1.0.0"`
- `apps/host.py`: use `APP_VERSION` from config instead of hardcoded `"0.13"`
- `main.py`: add `--version`/`-V` CLI flag via Typer eager option

## Test plan
- [ ] `mcp-cli --version` prints `mcp-cli <version>` and exits cleanly
- [ ] `mcp-cli -V` same behavior
- [ ] `mcp-cli --help` shows the `--version` option
- [ ] MCP Apps host page still shows correct version in footer
- [ ] Existing commands unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)