### PR TITLE
fix: disable startup banner that pollutes CLI output

### DIFF
--- a/src/mcp_cli/main.py
+++ b/src/mcp_cli/main.py
@@ -1733,14 +1733,18 @@ def ping_command(
 direct_registered.append("ping")
 
 
-# Show what we actually registered
-all_registered = registry_registered + direct_registered
-output.success("✓ MCP CLI ready")
-if all_registered:
-    output.info(f"  Available commands: {', '.join(sorted(all_registered))}")
-else:
-    output.warning("  Warning: No commands were successfully registered!")
-output.hint("  Use --help to see all options")
+# NOTE: Startup banner disabled — it runs at module-import time (before
+# Typer parses arguments), so it pollutes the output of --version, --help,
+# and every subcommand.  In chat mode it is immediately erased by
+# clear_screen().  Consider removing this block entirely.
+#
+# all_registered = registry_registered + direct_registered
+# output.success("✓ MCP CLI ready")
+# if all_registered:
+#     output.info(f"  Available commands: {', '.join(sorted(all_registered))}")
+# else:
+#     output.warning("  Warning: No commands were successfully registered!")
+# output.hint("  Use --help to see all options")
 
 
 # ──────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Disable the startup banner that runs at module-import time (before Typer parses arguments)
- The banner pollutes `--version`, `--help`, and every subcommand output
- In chat mode it is immediately erased by `clear_screen()` anyway

## Test plan
- [ ] `mcp-cli --help` no longer shows "✓ MCP CLI ready" banner before help text
- [ ] `mcp-cli chat` works normally (banner was always cleared by `clear_screen()`)
- [ ] All subcommands run cleanly without banner noise

🤖 Generated with [Claude Code](https://claude.com/claude-code)